### PR TITLE
Fix header to the older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,10 +29,6 @@
             </svg>
         </button>
 
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
 
         <div class="main-content">
             <!-- Left Sidebar -->


### PR DESCRIPTION
Remove Course Materials Assistant header, subheader, and horizontal row while preserving theme toggle functionality as requested in issue #6.

Generated with [Claude Code](https://claude.ai/code)